### PR TITLE
Refactor NetworkTooltip component by removing expand action

### DIFF
--- a/client/src/components/network-tooltip.test.tsx
+++ b/client/src/components/network-tooltip.test.tsx
@@ -43,9 +43,7 @@ describe('NetworkTooltip', () => {
     position: { x: 100, y: 200 },
     visible: true,
     isMainArtist: false,
-    isFirstDegreeCollaborator: true,
     onNetworkAction: vi.fn(),
-    onExpandAction: vi.fn(),
     onProfileAction: vi.fn(),
     onCollaborationAction: vi.fn(),
     onClose: vi.fn(),
@@ -111,8 +109,8 @@ describe('NetworkTooltip', () => {
     it('should call onNetworkAction when network link is clicked', () => {
       render(<NetworkTooltip {...defaultProps} />);
 
-      const networkLink = screen.getByText(`${mockArtistNode.name}'s network`);
-      fireEvent.click(networkLink);
+      const networkAction = screen.getByTestId('network-action');
+      fireEvent.click(networkAction);
 
       expect(defaultProps.onNetworkAction).toHaveBeenCalledWith(mockArtistNode);
       expect(defaultProps.onClose).toHaveBeenCalled();
@@ -127,50 +125,7 @@ describe('NetworkTooltip', () => {
     });
   });
 
-  describe('Expand Action', () => {
-    it('should render expand action for first-degree collaborators', () => {
-      render(<NetworkTooltip {...defaultProps} />);
-
-      const expandLink = screen.getByText(`Expand ${mockArtistNode.name}'s network`);
-      expect(expandLink).toBeInTheDocument();
-    });
-
-    it('should not render expand action for main artist', () => {
-      render(<NetworkTooltip {...defaultProps} isMainArtist={true} />);
-
-      const expandLink = screen.queryByText(`Expand ${mockArtistNode.name}'s network`);
-      expect(expandLink).not.toBeInTheDocument();
-    });
-
-    it('should not render expand action for non-first-degree collaborators', () => {
-      render(
-        <NetworkTooltip {...defaultProps} isFirstDegreeCollaborator={false} />
-      );
-
-      const expandLink = screen.queryByText(`Expand ${mockArtistNode.name}'s network`);
-      expect(expandLink).not.toBeInTheDocument();
-    });
-
-    it('should call onExpandAction when expand link is clicked', () => {
-      render(<NetworkTooltip {...defaultProps} />);
-
-      const expandLink = screen.getByText(`Expand ${mockArtistNode.name}'s network`);
-      fireEvent.click(expandLink);
-
-      expect(defaultProps.onExpandAction).toHaveBeenCalledWith(mockArtistNode);
-      expect(defaultProps.onClose).toHaveBeenCalled();
-    });
-
-    it('should have correct expand icon styling', () => {
-      render(<NetworkTooltip {...defaultProps} />);
-
-      const expandIcon = screen.getByText('+');
-      expect(expandIcon).toBeInTheDocument();
-      expect(expandIcon.parentElement).toHaveStyle({
-        backgroundColor: '#4CAF50',
-      });
-    });
-  });
+  // Expand Action removed from UI
 
   describe('Music Nerd Profile Action', () => {
     it('should render profile action for artists', () => {
@@ -190,8 +145,8 @@ describe('NetworkTooltip', () => {
     it('should call onProfileAction when profile link is clicked', () => {
       render(<NetworkTooltip {...defaultProps} />);
 
-      const profileLink = screen.getByText(`${mockArtistNode.name}'s Music Nerd profile`);
-      fireEvent.click(profileLink);
+      const profileAction = screen.getByTestId('profile-action');
+      fireEvent.click(profileAction);
 
       expect(defaultProps.onProfileAction).toHaveBeenCalledWith(mockArtistNode);
       expect(defaultProps.onClose).toHaveBeenCalled();
@@ -231,8 +186,8 @@ describe('NetworkTooltip', () => {
     it('should call onCollaborationAction when collaboration link is clicked', () => {
       render(<NetworkTooltip {...defaultProps} />);
 
-      const collaborationLink = screen.getByText('Collaboration details');
-      fireEvent.click(collaborationLink);
+      const collaborationAction = screen.getByTestId('collaboration-action');
+      fireEvent.click(collaborationAction);
 
       expect(defaultProps.onCollaborationAction).toHaveBeenCalledWith(mockArtistNode);
       expect(defaultProps.onClose).toHaveBeenCalled();
@@ -436,14 +391,15 @@ describe('NetworkTooltip', () => {
       
       // Check that network action appears first
       const networkAction = screen.getByTestId('network-action');
-      const expandAction = screen.getByTestId('expand-action');
       const profileAction = screen.getByTestId('profile-action');
       const collaborationAction = screen.getByTestId('collaboration-action');
 
       expect(networkAction).toBeInTheDocument();
-      expect(expandAction).toBeInTheDocument();
       expect(profileAction).toBeInTheDocument();
       expect(collaborationAction).toBeInTheDocument();
+      
+      // Ensure there are exactly three actions now that expand is removed
+      expect(actionElements.length).toBe(3);
     });
   });
 

--- a/client/src/components/network-tooltip.tsx
+++ b/client/src/components/network-tooltip.tsx
@@ -6,9 +6,7 @@ export interface NetworkTooltipProps {
   position: { x: number; y: number };
   visible: boolean;
   isMainArtist: boolean;
-  isFirstDegreeCollaborator: boolean;
   onNetworkAction: (node: NetworkNode) => void;
-  onExpandAction: (node: NetworkNode) => void;
   onProfileAction: (node: NetworkNode) => void;
   onCollaborationAction: (node: NetworkNode) => void;
   onClose: () => void;
@@ -19,9 +17,7 @@ export const NetworkTooltip: React.FC<NetworkTooltipProps> = ({
   position,
   visible,
   isMainArtist,
-  isFirstDegreeCollaborator,
   onNetworkAction,
-  onExpandAction,
   onProfileAction,
   onCollaborationAction,
   onClose,
@@ -256,7 +252,7 @@ export const NetworkTooltip: React.FC<NetworkTooltipProps> = ({
               flexShrink: 0,
             }}
           />
-          <span
+            <span
             style={{
               fontSize: linkFontSize,
               fontStyle: 'italic',
@@ -271,68 +267,6 @@ export const NetworkTooltip: React.FC<NetworkTooltipProps> = ({
             {node.name}&apos;s network
           </span>
         </div>
-
-        {/* Expand action - only for first-degree collaborators that aren't main artist */}
-        {isFirstDegreeCollaborator && !isMainArtist && (
-          <div
-            data-testid="expand-action"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap,
-              cursor: 'pointer',
-              width: '100%',
-              overflow: 'hidden',
-            }}
-            onClick={(e) => handleActionClick(e, () => onExpandAction(node))}
-            onKeyDown={(e) => handleKeyPress(e, () => onExpandAction(node))}
-            tabIndex={0}
-            role="button"
-            aria-label={`Expand ${node.name}'s network`}
-          >
-            <div
-              style={{
-                width: `${iconSize}px`,
-                height: `${iconSize}px`,
-                minWidth: `${iconSize}px`,
-                minHeight: `${iconSize}px`,
-                maxWidth: `${iconSize}px`,
-                maxHeight: `${iconSize}px`,
-                borderRadius: '50%',
-                cursor: 'pointer',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                backgroundColor: '#4CAF50',
-                flexShrink: 0,
-              }}
-            >
-              <span
-                style={{
-                  color: 'white',
-                  fontSize: '16px',
-                  fontWeight: 'bold',
-                }}
-              >
-                +
-              </span>
-            </div>
-            <span
-              style={{
-                fontSize: linkFontSize,
-                fontStyle: 'italic',
-                textDecoration: 'underline',
-                cursor: 'pointer',
-                whiteSpace: 'nowrap',
-                flex: 1,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              Expand {node.name}&apos;s network
-            </span>
-          </div>
-        )}
 
         {/* Music Nerd profile action - only for artists */}
         {isArtist && (

--- a/client/src/components/network-visualizer.test.tsx
+++ b/client/src/components/network-visualizer.test.tsx
@@ -457,9 +457,7 @@ describe("NetworkVisualizer Integration Tests", () => {
           position: { x: 150, y: 250 },
           visible: true,
           isMainArtist: expect.any(Boolean),
-          isFirstDegreeCollaborator: expect.any(Boolean),
           onNetworkAction: tooltipActiveState.handleNetworkAction,
-          onExpandAction: tooltipActiveState.handleExpandAction,
           onProfileAction: tooltipActiveState.handleProfileAction,
           onCollaborationAction: tooltipActiveState.handleCollaborationAction,
           onClose: tooltipActiveState.hideTooltip

--- a/client/src/components/network-visualizer.tsx
+++ b/client/src/components/network-visualizer.tsx
@@ -416,22 +416,7 @@ export default function NetworkVisualizer({
                   return false;
                 }
               })()}
-              isFirstDegreeCollaborator={(() => {
-                try {
-                  const mainArtistNode = finalDisplayData.nodes.find(node => node.size === 30 && node.type === 'artist');
-                  return mainArtistNode && finalDisplayData.links.some(link => {
-                    const sourceId = typeof link.source === 'string' ? link.source : link.source.id;
-                    const targetId = typeof link.target === 'string' ? link.target : link.target.id;
-                    return (sourceId === mainArtistNode.name && targetId === tooltip.currentNode?.name) || 
-                           (sourceId === tooltip.currentNode?.name && targetId === mainArtistNode.name);
-                  }) || false;
-                } catch (error) {
-                  handleError(error as Error, 'tooltip collaborator calculation');
-                  return false;
-                }
-              })()}
               onNetworkAction={tooltip.handleNetworkAction}
-              onExpandAction={tooltip.handleExpandAction}
               onProfileAction={tooltip.handleProfileAction}
               onCollaborationAction={tooltip.handleCollaborationAction}
               onClose={tooltip.hideTooltip}

--- a/client/src/hooks/use-tooltip.test.ts
+++ b/client/src/hooks/use-tooltip.test.ts
@@ -360,27 +360,7 @@ describe('useTooltip', () => {
       );
     });
 
-    it('should handle expand network action', async () => {
-      const { result } = renderHook(() =>
-        useTooltip({
-          networkData: mockNetworkData,
-          config: mockConfig,
-          networkDataHook: mockNetworkDataHook,
-          callbacks: mockCallbacks,
-        })
-      );
-
-      const mockNode = mockNetworkData.nodes[1]; // producer node
-
-      await act(async () => {
-        await result.current.handleExpandAction(mockNode);
-      });
-
-      expect(mockNetworkDataHook.expandNodeNetwork).toHaveBeenCalledWith(
-        mockNode.name,
-        mockNode.artistId
-      );
-    });
+    // Expand network action removed from UI
 
     it('should handle collaboration details action', () => {
       const { result } = renderHook(() =>


### PR DESCRIPTION
- Eliminated the expand action for first-degree collaborators from the NetworkTooltip UI and related tests.
- Updated event handling to use data-testid attributes for network, profile, and collaboration actions.
- Adjusted props and tests accordingly to reflect the removal of the expand action, ensuring cleaner and more focused functionality.